### PR TITLE
⚡️ Add image path to .launch

### DIFF
--- a/darknet_ros/launch/darknet_ros.launch
+++ b/darknet_ros/launch/darknet_ros.launch
@@ -3,7 +3,7 @@
 <launch>
   <!-- Console launch prefix -->
   <arg name="launch_prefix" default=""/>
-  <arg name="image" default="perse/camera/image_raw" />
+  <arg name="image" default="/perse/camera/image_raw" />
 
   <!-- Config and weights folder. -->
   <arg name="yolo_weights_path"          default="$(find darknet_ros)/yolo_network_config/weights"/>

--- a/darknet_ros/launch/darknet_ros.launch
+++ b/darknet_ros/launch/darknet_ros.launch
@@ -3,7 +3,7 @@
 <launch>
   <!-- Console launch prefix -->
   <arg name="launch_prefix" default=""/>
-  <arg name="image" default="/camera/rgb/image_raw" />
+  <arg name="image" default="perse/camera/image_raw" />
 
   <!-- Config and weights folder. -->
   <arg name="yolo_weights_path"          default="$(find darknet_ros)/yolo_network_config/weights"/>


### PR DESCRIPTION
Com isso, podemos rodar a darknet sem o parâmetro "image", ou seja apenas com:
`
roslaunch darknet_ros darknet_ros.launch
`